### PR TITLE
updates to blog page to swap gnomad to ourdna

### DIFF
--- a/src/components/layout.js
+++ b/src/components/layout.js
@@ -75,7 +75,7 @@ const Layout = ({ children, title }) => {
       >
         <meta
           name="description"
-          content="The Genome Aggregation Database (gnomAD) is a resource developed by an international coalition of investigators, with the goal of aggregating and harmonizing both exome and genome sequencing data from a wide variety of large-scale sequencing projects, and making summary data available for the wider scientific community."
+          content="The OurDNA browser provides access to harmonised, aggregated genome and exome sequences from the OurDNA program. The OurDNA dataset includes healthy individuals that self-identify as having ancestry from a subset of multicultural Australian communities. The OurDNA browser is maintained by the Centre for Population Genomics and is part of federated gnomAD."
         />
       </Helmet>
       <TopBarWrapper>

--- a/src/components/list.js
+++ b/src/components/list.js
@@ -11,7 +11,7 @@ const ArticleList = ({ heading, posts, extraSidebarContent }) => {
       <h1>News</h1>
       <p>
         The news page highlights new features, versions, or other major announcements. See our{" "}
-        <Link to="/changelog">changelog</Link> for all changes to gnomAD, including minor ones.
+        <Link to="/changelog">changelog</Link> for all changes to OurDNA, including minor ones.
       </p>
       <br />
       <div className="article-list-inner">

--- a/src/pages/changelog.js
+++ b/src/pages/changelog.js
@@ -9,7 +9,7 @@ const ChangelogPage = ({ data }) => {
     <Layout title="Changelog">
       <div className="article-list no-sidebar">
         <h1>Changelog</h1>
-        <p>The changelog contains a record of all changes made to gnomAD, small or large.</p>
+        <p>The changelog contains a record of all changes made to OurDNA, small or large.</p>
         <div className="article-list-inner">
           {data.allMarkdownRemark.edges.map(({ node }) => {
             const title = node.frontmatter.title || node.fields.slug;


### PR DESCRIPTION
Two swaps of gnomAD to OurDNA.

The change to `layout.js` content was taken from the browser repo, `browser/src/index.html`